### PR TITLE
ci: SHA-pin dependabot/fetch-metadata (v3.1.0)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dependabot/fetch-metadata@v3
+      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         id: metadata
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pins the last floating action tag (`dependabot/fetch-metadata@v3`) to its immutable SHA `25dd0e34` (v3.1.0), consistent with `actions/checkout` and `actions/setup-node` which are already SHA-pinned.

https://claude.ai/code/session_01JkPiYPmw3bPCFGv8EYAbp8