### PR TITLE
chore: typecheck e build della demo in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Build demo
+        run: npm run build-demo

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/node": "^26.2.0",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vitest/coverage-v8": "^4.1.9",
         "@vue/test-utils": "^2.4.11",
@@ -20,7 +21,8 @@
         "vite": "^8.1.0",
         "vite-plugin-dts": "^5.0.3",
         "vitest": "^4.1.9",
-        "vue": "^3.5.39"
+        "vue": "^3.5.39",
+        "vue-tsc": "^3.3.9"
       },
       "engines": {
         "node": ">=20"
@@ -915,6 +917,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
@@ -1399,6 +1411,22 @@
         "@vue/shared": "3.5.41"
       }
     },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
+      "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.1",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.41",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
@@ -1505,6 +1533,13 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -2989,6 +3024,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -3709,6 +3751,13 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unplugin": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
@@ -4018,6 +4067,23 @@
       "integrity": "sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.9.tgz",
+      "integrity": "sha512-TS3Y1ux/IRoE8OCP2PpACAeOseuIs0UvWrcr7u+w3PmfY+SlCfEf8zjrBgnQksHUgLpthi5vHlffcQTQTdPBZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.9"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -49,20 +49,22 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && npm run typecheck-demo",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "lint": "eslint .",
     "prepublishOnly": "npm run typecheck && npm run test && npm run build",
     "build-demo": "vite build --config vite.config.demo.ts",
-    "dev-demo": "vite --config vite.config.demo.ts"
+    "dev-demo": "vite --config vite.config.demo.ts",
+    "typecheck-demo": "vue-tsc --noEmit -p tsconfig.demo.json"
   },
   "peerDependencies": {
     "vue": "^3.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/node": "^26.2.0",
     "@vitejs/plugin-vue": "^6.0.8",
     "@vitest/coverage-v8": "^4.1.9",
     "@vue/test-utils": "^2.4.11",
@@ -73,7 +75,8 @@
     "vite": "^8.1.0",
     "vite-plugin-dts": "^5.0.3",
     "vitest": "^4.1.9",
-    "vue": "^3.5.39"
+    "vue": "^3.5.39",
+    "vue-tsc": "^3.3.9"
   },
   "engines": {
     "node": ">=20"

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["node", "vite/client"],
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "paths": {
+      "vue-viewports": ["./src/index.ts"]
+    }
+  },
+  "include": ["demo/**/*.ts", "demo/**/*.vue", "vite.config.demo.ts"]
+}


### PR DESCRIPTION
Le demo aggiunte non erano coperte da nessun check: `tsc` non sa leggere gli SFC, e `build-demo` girava solo nel workflow Pages, cioe' **dopo** il merge.

- `tsconfig.demo.json` + `vue-tsc`: lo script `typecheck` ora copre anche `demo/` e `vite.config.demo.ts`. Il `paths` rispecchia l'alias di Vite, quindi la demo si typechecka contro i sorgenti veri della libreria.
- step "Build demo" in `ci.yml`: una demo rotta ora blocca la PR invece di rompere il deploy su master.

Il typecheck ha ripagato subito, con due problemi che erano gia' in produzione:
- `vue-geolocation`: la demo leggeva `error.name`, che su `GeolocationPositionError` non esiste (ha `code` numerico). Ora distingue i due rami dell'union.
- `vue-geolocation`: la demo importava da `vue-geolocation` (nome del repo) invece che da `vue-browser-geolocation` (nome del pacchetto pubblicato).
- `@types/node` aggiunto dove mancava (smooth-vuebar, vue-viewports).

Verifica: lint, typecheck, coverage, build libreria e build demo verdi in locale su tutti i repo; percorso di errore e di successo della demo geolocation ricontrollati in Chrome.